### PR TITLE
Update fnv1a.h

### DIFF
--- a/base/sdk/hash/fnv1a.h
+++ b/base/sdk/hash/fnv1a.h
@@ -16,7 +16,7 @@ namespace FNV1A
 	/* create compile time hash */
 	constexpr FNV1A_t HashConst(const char* szString, const FNV1A_t uValue = ullBasis) noexcept
 	{
-		return !*szString ? uValue : HashConst(&szString[1], (uValue ^ FNV1A_t(szString[0])) * ullPrime);
+		return (szString[0] == '\0') ? uValue : HashConst(&szString[1], (uValue ^ FNV1A_t(szString[0])) * ullPrime);
 	}
 
 	/* create runtime hash */


### PR DESCRIPTION
We are hashing strings, so it is better to be explicit that we check if the string is empty rather than check if the pointer is empty.

And you are using the Hungarian notation, so `szString` is a zero-terminated string, otherwise it would have been `pszString` (but that makes no sense here).