### PR TITLE
Push/Pop cliprect to fix menu visual bug

### DIFF
--- a/base/core/menu.cpp
+++ b/base/core/menu.cpp
@@ -127,10 +127,17 @@ void W::MainWindow(IDirect3DDevice9* pDevice)
 		{
 			ImVec2 vecPos = ImGui::GetCursorScreenPos();
 			float flWindowWidth = ImGui::GetWindowWidth();
+			ImDrawList* pWindowDrawList = ImGui::GetWindowDrawList();
+
+			// push cliprect so header separator doesnt draw over other windows
+			ImGui::PushClipRect(ImVec2(vecPos.x - 8.f, vecPos.y - 8.f), ImVec2(vecPos.x + flWindowWidth - 8.f, vecPos.y - 6.f), false);
 
 			// header separate line
-			pForegroundDrawList->AddRectFilledMultiColor(ImVec2(vecPos.x - 8.f, vecPos.y - 6.f), ImVec2(vecPos.x + flWindowWidth - flWindowWidth / 3.f - 8.f, vecPos.y - 8.f), IM_COL32(75, 50, 105, 255), IM_COL32(110, 100, 130, 255), IM_COL32(110, 100, 130, 255), IM_COL32(75, 50, 105, 255));
-			pForegroundDrawList->AddRectFilledMultiColor(ImVec2(vecPos.x + flWindowWidth - flWindowWidth / 3.f - 8.f, vecPos.y - 6.f), ImVec2(vecPos.x + flWindowWidth - 8.f, vecPos.y - 8.f), IM_COL32(110, 100, 130, 255), IM_COL32(75, 50, 105, 255), IM_COL32(75, 50, 105, 255), IM_COL32(110, 100, 130, 255));
+			pWindowDrawList->AddRectFilledMultiColor(ImVec2(vecPos.x - 8.f, vecPos.y - 6.f), ImVec2(vecPos.x + flWindowWidth - flWindowWidth / 3.f - 8.f, vecPos.y - 8.f), IM_COL32(75, 50, 105, 255), IM_COL32(110, 100, 130, 255), IM_COL32(110, 100, 130, 255), IM_COL32(75, 50, 105, 255));
+			pWindowDrawList->AddRectFilledMultiColor(ImVec2(vecPos.x + flWindowWidth - flWindowWidth / 3.f - 8.f, vecPos.y - 6.f), ImVec2(vecPos.x + flWindowWidth - 8.f, vecPos.y - 8.f), IM_COL32(110, 100, 130, 255), IM_COL32(75, 50, 105, 255), IM_COL32(75, 50, 105, 255), IM_COL32(110, 100, 130, 255));
+
+			// restore cliprect
+			ImGui::PopClipRect();
 
 			// add tabs
 			static std::array<CTab, 4U> const arrTabs =


### PR DESCRIPTION
So right now if you try to create another window in imgui (lets say spectatorlist) and move it around, the separator line in the menu draws over it.

![image](https://user-images.githubusercontent.com/72025514/104390828-9902d400-550c-11eb-9a12-74454478566b.png)

This is because we draw the line in pForegroundDrawList. If we put it in pWindowDrawList and push a cliprect to override window padding we can draw the line inside of the window itself while maintaining position and size. 

![image](https://user-images.githubusercontent.com/72025514/104390915-c5b6eb80-550c-11eb-956f-4c3efbc90e7a.png)
