### PR TITLE
add missing parameter to RegisterConCommand virtual function

### DIFF
--- a/base/sdk/interfaces/iconvar.h
+++ b/base/sdk/interfaces/iconvar.h
@@ -52,7 +52,7 @@ class IConVar : public IAppSystem
 {
 public:
 	virtual CVarDLLIdentifier_t	AllocateDLLIdentifier() = 0;
-	virtual void			RegisterConCommand(CConVar* pCommandBase) = 0;
+	virtual void			RegisterConCommand(CConVar* pCommandBase, int unk=1) = 0;
 	virtual void			UnregisterConCommand(CConVar* pCommandBase) = 0;
 	virtual void			UnregisterConCommands(CVarDLLIdentifier_t id) = 0;
 	virtual const char*		GetCommandLineValue(const char* szVariableName) = 0;

--- a/base/sdk/interfaces/iconvar.h
+++ b/base/sdk/interfaces/iconvar.h
@@ -52,7 +52,7 @@ class IConVar : public IAppSystem
 {
 public:
 	virtual CVarDLLIdentifier_t	AllocateDLLIdentifier() = 0;
-	virtual void			RegisterConCommand(CConVar* pCommandBase, int unk=1) = 0;
+	virtual void			RegisterConCommand(CConVar* pCommandBase, int iDefaultValue = 1) = 0;
 	virtual void			UnregisterConCommand(CConVar* pCommandBase) = 0;
 	virtual void			UnregisterConCommands(CVarDLLIdentifier_t id) = 0;
 	virtual const char*		GetCommandLineValue(const char* szVariableName) = 0;


### PR DESCRIPTION
so i discovered a problem when trying to use the CSpoofedConvar class, kept getting something about ESP not being preserved etc etc. so i assumed an incorrect vtable index but all seemed right. a quick google search netted me [this](https://www.unknowncheats.me/forum/2563246-post3.html)

all works now :)