### PR TITLE
Add Hud Blur Disable

### DIFF
--- a/base/cinnamon.vcxproj
+++ b/base/cinnamon.vcxproj
@@ -218,8 +218,8 @@
     <OutDir>$(SolutionDir)build\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)log\$(ProjectName)\$(Configuration)\</IntDir>
     <TargetName>base</TargetName>
-    <IncludePath>$(SolutionDir)dependencies\freetype\include;$(SolutionDir)dependencies\json;$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
-    <LibraryPath>$(SolutionDir)dependencies\freetype\win32;$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
+    <IncludePath>E:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;$(SolutionDir)dependencies\freetype\include;$(SolutionDir)dependencies\json;$(DXSDK_DIR)Include;$(IncludePath)</IncludePath>
+    <LibraryPath>E:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;$(SolutionDir)dependencies\freetype\win32;$(DXSDK_DIR)Lib\x86;$(LibraryPath)</LibraryPath>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/base/core/hooks.cpp
+++ b/base/core/hooks.cpp
@@ -205,6 +205,8 @@ long D3DAPI H::hkEndScene(IDirect3DDevice9* pDevice)
 		ImGui::EndFrame();
 		ImGui::Render();
 
+		CMiscellaneous::Get().DisablePanoramaBlur();
+
 		// render draw lists from draw data
 		ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
 
@@ -404,6 +406,8 @@ void FASTCALL H::hkFrameStageNotify(IBaseClientDll* thisptr, int edx, EClientFra
 	if (I::Engine->IsTakingScreenshot())
 		return oFrameStageNotify(thisptr, edx, stage);
 
+	
+
 	CBaseEntity* pLocal = CBaseEntity::GetLocalPlayer();
 
 	if (pLocal == nullptr)
@@ -442,6 +446,7 @@ void FASTCALL H::hkFrameStageNotify(IBaseClientDll* thisptr, int edx, EClientFra
 	}
 	case FRAME_RENDER_START:
 	{
+		
 		/*
 		 * start rendering the scene
 		 * e.g. remove visual punch, thirdperson, other render/update stuff

--- a/base/core/menu.cpp
+++ b/base/core/menu.cpp
@@ -535,6 +535,7 @@ void T::Miscellaneous()
 			ImGui::Checkbox(XorStr("ping spike"), &C::Get<bool>(Vars.bMiscPingSpike));
 			ImGui::SliderFloat(XorStr("latency factor"), &C::Get<float>(Vars.flMiscLatencyFactor), 0.1f, 1.0f, "%.1f second");
 			ImGui::Checkbox(XorStr("reveal ranks"), &C::Get<bool>(Vars.bMiscRevealRanks));
+			ImGui::Checkbox(XorStr("Disable Hud Blur"), &C::Get<bool>(Vars.bMiscDisableHudBlur));
 			ImGui::Checkbox(XorStr("unlock inventory"), &C::Get<bool>(Vars.bMiscUnlockInventory));
 			ImGui::Checkbox(XorStr("anti-untrusted"), &C::Get<bool>(Vars.bMiscAntiUntrusted));
 			ImGui::PopStyleVar();

--- a/base/core/variables.h
+++ b/base/core/variables.h
@@ -222,6 +222,7 @@ struct Variables_t
 	C_ADD_VARIABLE(bool, bMiscPingSpike, false);
 	C_ADD_VARIABLE(float, flMiscLatencyFactor, 0.4f);
 	C_ADD_VARIABLE(bool, bMiscRevealRanks, false);
+	C_ADD_VARIABLE(bool, bMiscDisableHudBlur, false);
 	C_ADD_VARIABLE(bool, bMiscUnlockInventory, false);
 	C_ADD_VARIABLE(bool, bMiscAntiUntrusted, true);
 	#pragma endregion

--- a/base/features/misc.cpp
+++ b/base/features/misc.cpp
@@ -10,9 +10,12 @@
 #include "../core/interfaces.h"
 // used: angle-vector calculations
 #include "../utilities/math.h"
+#include "../utilities/logging.h"
+#include <iostream>
 
 void CMiscellaneous::Run(CUserCmd* pCmd, CBaseEntity* pLocal, bool& bSendPacket)
 {
+
 	if (!pLocal->IsAlive())
 		return;
 
@@ -187,6 +190,16 @@ void CMiscellaneous::BunnyHop(CUserCmd* pCmd, CBaseEntity* pLocal) const
 		bLastJumped = false;
 		bShouldFake = false;
 	}
+}
+
+void CMiscellaneous::DisablePanoramaBlur() {
+
+	L::Print(XorStr("Applicando Blur"));
+	std::cout << "Check Blur";
+	static CConVar* Blur = I::ConVar->FindVar(XorStr("@panorama_disable_blur"));
+	
+	Blur->SetValue(C::Get<bool>(Vars.bMiscDisableHudBlur));
+
 }
 
 void CMiscellaneous::AutoStrafe(CUserCmd* pCmd, CBaseEntity* pLocal)

--- a/base/features/misc.cpp
+++ b/base/features/misc.cpp
@@ -194,12 +194,8 @@ void CMiscellaneous::BunnyHop(CUserCmd* pCmd, CBaseEntity* pLocal) const
 
 void CMiscellaneous::DisablePanoramaBlur() {
 
-	L::Print(XorStr("Applicando Blur"));
-	std::cout << "Check Blur";
 	static CConVar* Blur = I::ConVar->FindVar(XorStr("@panorama_disable_blur"));
-	
 	Blur->SetValue(C::Get<bool>(Vars.bMiscDisableHudBlur));
-
 }
 
 void CMiscellaneous::AutoStrafe(CUserCmd* pCmd, CBaseEntity* pLocal)

--- a/base/features/misc.h
+++ b/base/features/misc.h
@@ -23,10 +23,14 @@ public:
 	void AutoPistol(CUserCmd* pCmd, CBaseEntity* pLocal);
 	/* dont send packets for a certain number of ticks */
 	void FakeLag(CBaseEntity* pLocal, bool& bSendPacket);
+
+	void DisablePanoramaBlur();
 private:
 	// Movement
 	/* automatic jump when steps on the ground */
 	void BunnyHop(CUserCmd* pCmd, CBaseEntity* pLocal) const;
+	
+	
 	/* strafes on optimal sides for maximum speed in air */
 	void AutoStrafe(CUserCmd* pCmd, CBaseEntity* pLocal);
 };


### PR DESCRIPTION
It simply modifies a deck that disables or activates the blur effect of the panorama.
I'm sorry for the lack of organization, and horrible ways of performing the function, I'm starting to learn cheats now.
If you have a better way to do this just comment, I will be attentive to suggestions for changes.