### PR TITLE
Small typo(maybe?)

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -11,7 +11,7 @@ workspace "base"
 			"base/**.h",
 			"dependencies/imgui/**.cpp",
 			"dependencies/imgui/**.h",
-			"dependencies/minhook/**.cpp",
+			"dependencies/minhook/**.c",
 			"dependencies/minhook/**.h",
 			"resources/*.h"
 		}


### PR DESCRIPTION
Fixes include errors when using premake, cuz minhook has C files too which dont get included causing unresolved symbol errors