### PR TITLE
Implement DllMain-safe (non-deadlocking, FreeLibrary-able) loading mechanism 

### DIFF
--- a/base/core.cpp
+++ b/base/core.cpp
@@ -24,8 +24,10 @@
 // used: hooks setup/destroy
 #include "core/hooks.h"
 
-DWORD WINAPI OnDllAttach(LPVOID lpParameter)
+DWORD WINAPI MainThread(LPVOID lpParameter)
 {
+  const auto loadHelper = reinterpret_cast<CLoadHelper*>(lpParameter);
+
 	try
 	{
     // basic process check
@@ -144,17 +146,12 @@ DWORD WINAPI OnDllAttach(LPVOID lpParameter)
 		_RPT0(_CRT_ERROR, ex.what());
 		#else
 		// unload
-		FreeLibraryAndExitThread(static_cast<HMODULE>(lpParameter), EXIT_FAILURE);
+		FreeLibraryAndExitThread(G::hDll, EXIT_FAILURE);
 		#endif
 	}
 
-	return 1UL;
-}
-
-DWORD WINAPI OnDllDetach(LPVOID lpParameter)
-{
-	// unload cheat if pressed specified key
-	while (!IPT::IsKeyReleased(C::Get<int>(Vars.iPanicKey)))
+	// unload cheat if pressed specified key or if loadhelper requests it
+	while (!IPT::IsKeyReleased(C::Get<int>(Vars.iPanicKey)) && !loadHelper->bUnloadRequested)
 		std::this_thread::sleep_for(500ms);
 
 	#if 0
@@ -189,27 +186,42 @@ DWORD WINAPI OnDllDetach(LPVOID lpParameter)
 		L::ofsFile.close();
 	#endif
 
-	 // free our library memory from process and exit from our thread
-	FreeLibraryAndExitThread((HMODULE)lpParameter, EXIT_SUCCESS);
+  // We should only free the library if the loadhelper DIDNT request it. If it did, then it will do it itself.
+  if (!loadHelper->bUnloadRequested)
+    FreeLibraryAndExitThread(G::hDll, EXIT_SUCCESS);
+
+  // Signal that thread has exited
+  loadHelper->bThreadExited = true;
+
+  // Return success
+  return EXIT_SUCCESS;  
 }
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 {
+  static auto loadHelper = CLoadHelper();
+
 	if (dwReason == DLL_PROCESS_ATTACH)
 	{
 		// save our module
 		G::hDll = hModule;
 
-		// create main thread
-		if (auto hThread = CreateThread(nullptr, 0U, OnDllAttach, hModule, 0UL, nullptr); hThread != nullptr)
-			CloseHandle(hThread);
+    const auto hThread = CreateThread(nullptr, 0U, MainThread, &loadHelper, 0U, nullptr);
+    if (hThread == nullptr)
+      return FALSE;
+  
+    CloseHandle(hThread);
+	} else if (dwReason == DLL_PROCESS_DETACH)
+  {
+    // Signal to the other thread to exit using loadhelper
+    loadHelper.bUnloadRequested = true;
 
-		// create detach thread
-		if (auto hThread = CreateThread(nullptr, 0U, OnDllDetach, hModule, 0UL, nullptr); hThread != nullptr)
-			CloseHandle(hThread);
+    // Wait for the other thread to exit
+    while (!loadHelper.bThreadExited)
+      Sleep(100);
 
-		return TRUE;
-	}
+    // At this point, the other thread has exited and we are free to return.
+  }
 
 	return FALSE;
 }

--- a/base/core.cpp
+++ b/base/core.cpp
@@ -199,7 +199,7 @@ DWORD WINAPI MainThread(LPVOID lpParameter)
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 {
-  static auto loadHelper = CLoadHelper();
+  static auto loadHelper = LoadHelper_t();
 
 	if (dwReason == DLL_PROCESS_ATTACH)
 	{

--- a/base/core.cpp
+++ b/base/core.cpp
@@ -197,9 +197,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 {
 	if (dwReason == DLL_PROCESS_ATTACH)
 	{
-		// disable DLL_THREAD_ATTACH and DLL_THREAD_DETACH reasons to call
-		DisableThreadLibraryCalls(hModule);
-
 		// save our module
 		G::hDll = hModule;
 

--- a/base/core.cpp
+++ b/base/core.cpp
@@ -26,7 +26,7 @@
 
 DWORD WINAPI MainThread(LPVOID lpParameter)
 {
-  const auto loadHelper = reinterpret_cast<CLoadHelper*>(lpParameter);
+  const auto loadHelper = reinterpret_cast<LoadHelper_t*>(lpParameter);
 
 	try
 	{

--- a/base/core.cpp
+++ b/base/core.cpp
@@ -28,6 +28,13 @@ DWORD WINAPI OnDllAttach(LPVOID lpParameter)
 {
 	try
 	{
+    // basic process check
+		if (MEM::GetModuleBaseHandle(XorStr("csgo.exe")) == nullptr)
+		{
+			MessageBox(nullptr, XorStr("this cannot be injected in another process\nopen <csgo.exe> to inject"), XorStr("qo0 base"), MB_OK);
+			return FALSE;
+		}
+
 		/*
 		 * @note: serverbrowser.dll is last loaded module (u can seen it when debug)
 		 * here is check for all modules loaded
@@ -192,13 +199,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, LPVOID lpReserved)
 	{
 		// disable DLL_THREAD_ATTACH and DLL_THREAD_DETACH reasons to call
 		DisableThreadLibraryCalls(hModule);
-
-		// basic process check
-		if (MEM::GetModuleBaseHandle(XorStr("csgo.exe")) == nullptr)
-		{
-			MessageBox(nullptr, XorStr("this cannot be injected in another process\nopen <csgo.exe> to inject"), XorStr("qo0 base"), MB_OK);
-			return FALSE;
-		}
 
 		// save our module
 		G::hDll = hModule;

--- a/base/utilities.h
+++ b/base/utilities.h
@@ -11,7 +11,7 @@
 #include "utilities/entitylistener.h"
 
 /* used to signal between dllmain and our thread */
-struct CLoadHelper 
+struct LoadHelper_t
 {
   volatile bool bUnloadRequested : 1;
   volatile bool bThreadExited : 1;

--- a/base/utilities.h
+++ b/base/utilities.h
@@ -15,7 +15,7 @@ struct LoadHelper_t
 {
   volatile bool bUnloadRequested : 1;
   volatile bool bThreadExited : 1;
-}
+};
 
 /* internal implementation for measuring specific time intervals */
 class CTimer

--- a/base/utilities.h
+++ b/base/utilities.h
@@ -10,6 +10,13 @@
 // used: entity listerner setup
 #include "utilities/entitylistener.h"
 
+/* used to signal between dllmain and our thread */
+struct CLoadHelper 
+{
+  volatile bool bUnloadRequested : 1;
+  volatile bool bThreadExited : 1;
+}
+
 /* internal implementation for measuring specific time intervals */
 class CTimer
 {


### PR DESCRIPTION
I haven't tested this code because I don't have enough bandwidth to download Visual Studio again, at least it's syntactically correct.

This PR adds compatibility with more `LoadLibrary` DLL injectors. These injectors work by just calling `LoadLibrary(pszDll)` in the target process. Some also support *uninjecting* by calling `FreeLibrary(hDll)` in the target process. The current implementation of `DllMain` is incompatible with this function call, as there is no handler for `DLL_PROCESS_DETACH`.

Changes include:
 - Removing all `DllMain`-unsafe code (anything non-Win32, as well as `MessageBox` calls, these are NOT intended to be used inside of DllMain)
 - Combining OnDllAttach and OnDllDetach threads into one. Now at the end of initialization, the thread waits for either the panic key to be pressed, or for DllMain to signal that the thread should exit.