### PR TITLE
add std::vector<Color> to config system

### DIFF
--- a/base/sdk/datatypes/color.h
+++ b/base/sdk/datatypes/color.h
@@ -264,6 +264,23 @@ public:
 		return Color(r, g, b, flAlpha);
 	}
 
+	/* return RGB color converted from heximal input */
+	static Color FromHex(unsigned uHexValue)
+	{
+		int iR = (uHexValue >> 24) & 0xFF;
+		int iG = (uHexValue >> 16) & 0xFF;
+		int iB = (uHexValue >> 8) & 0xFF;
+		int iA = (uHexValue) & 0xFF;
+
+		return Color( iR, iG, iB, iA );
+	}
+
+	/* convert color to heximal value */
+	[[nodiscard]] unsigned GetHex() const
+	{
+		return (((arrColor[COLOR_R]) << 24) | ((arrColor[COLOR_G]) << 16) | ((arrColor[ COLOR_B ]) << 8) | ((arrColor[COLOR_A])));
+	}
+
 private:
 	std::array<std::uint8_t, 4U> arrColor;
 };


### PR DESCRIPTION
changing from reading the unsigned char from 0 - 255 ( r, g, b, a ) value to hexadecimal as unsigned int ( 0xFFFFFFFF overflow'd int )

so that we can have a vector config for Color class which is missing in this base, I'm surprised that no one has done this as a pull request yet... 