### PR TITLE
Update prediction.cpp

### DIFF
--- a/base/features/prediction.cpp
+++ b/base/features/prediction.cpp
@@ -164,8 +164,10 @@ void PREDICTION::OnPostMove(CBasePlayer* pLocal, CUserCmd* pCmd)
 
 	// finish command
 	pLocal->GetCurrentCommand() = nullptr;
-	*piPredictionRandomSeed = -1;
-	*ppPredictionPlayer = nullptr;
+	if (piPredictionRandomSeed != nullptr)
+		*piPredictionRandomSeed = -1;
+	if (ppPredictionPlayer != nullptr)
+		*ppPredictionPlayer = nullptr;
 
 	// reset move
 	I::GameMovement->Reset();


### PR DESCRIPTION
Fix a crash when entering retakes and a rare crash that happens sometimes randomly also fixes a crash that can come from uninjecting and then injecting back in the same game